### PR TITLE
Use rdmd for dubhash prebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,12 @@ when using the **--inplace** option.
 
 ### Installing with DUB
 
+Add the repository to your local DUB registry so subsequent runs
+won't have to build the `dubhash` helper again:
+
 ```sh
-> dub run dfmt -- -h
+dub add-local .
+dub run dfmt -- -h
 ```
 
 ### Building from source using Make

--- a/dub.json
+++ b/dub.json
@@ -15,6 +15,6 @@
         "built_with_dub"
     ],
     "preBuildCommands" : [
-      "$DC -run \"$PACKAGE_DIR/dubhash.d\""
+      "rdmd --compiler=$DC \"$PACKAGE_DIR/dubhash.d\""
     ]
 }


### PR DESCRIPTION
## Summary
- run `dubhash.d` via `rdmd` so it isn't rebuilt on every run
- document `dub add-local` usage

## Testing
- `dub build`
- `dub run dfmt -- --version`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_684d58d99a34832ca3eb296b8eeb0ff9