### PR TITLE
Use rdmd for dubhash prebuild step

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ when using the **--inplace** option.
 ### Building from source using dub
 * Clone the repository
 * run `dub build --build=release`, optionally with `--compiler=ldc2`
-* ensure `rdmd` is in your `PATH` (it comes with DMD/ldc via the official
+* Ensure `rdmd` is in your `PATH` (it comes with DMD/ldc via the official
   `install.sh` script)
   
 The first run will build a small helper tool via `rdmd`. Subsequent

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ when using the **--inplace** option.
 ### Building from source using dub
 * Clone the repository
 * run `dub build --build=release`, optionally with `--compiler=ldc2`
+* ensure `rdmd` is in your `PATH` (it comes with DMD/ldc via the official
+  `install.sh` script)
+  
+The first run will build a small helper tool via `rdmd`. Subsequent
+invocations reuse the cached binary and are noticeably faster.
 
 ## Using
 By default, dfmt reads its input from **stdin** and writes to **stdout**.

--- a/dub.json
+++ b/dub.json
@@ -15,6 +15,6 @@
         "built_with_dub"
     ],
     "preBuildCommands" : [
-      "$DC -run \"$PACKAGE_DIR/dubhash.d\""
+      "rdmd --compiler=$DC \"$PACKAGE_DIR/dubhash.d\""
     ]
 }


### PR DESCRIPTION
## Summary
- run `dubhash.d` via `rdmd` so the helper is cached
- document the rdmd requirement in the README

## Testing
- `dub build -v` (first run shows `Running rdmd` and takes ~3s)
- `dub build -v` again (no rdmd invocation, finishes in ~0.06s)
- `dub run dfmt -- --version`
- `dub test`


------
https://chatgpt.com/codex/tasks/task_e_684d58d99a34832ca3eb296b8eeb0ff9